### PR TITLE
Add version flag for license checker

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -256,6 +256,7 @@ check-license --summary-only     # サマリーのみ表示
 check-license --verbose          # 詳細な内容を表示
 check-license --ignore node_modules,dist  # 特定のディレクトリを無視
 check-license --output report.csv # 結果をCSVファイルに保存
+check-license --version          # ツールのバージョンを表示
 check-license --help             # ヘルプを表示
 ```
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ check-license --summary-only     # Show summary only
 check-license --verbose          # Show detailed content
 check-license --ignore node_modules,dist  # Ignore specific directories
 check-license --output report.csv # Save results to CSV file
+check-license --version          # Show tool version
 check-license --help             # Show help
 ```
 

--- a/check-license
+++ b/check-license
@@ -13,6 +13,9 @@ from collections import defaultdict
 from datetime import datetime
 import hashlib
 
+# Tool version
+__version__ = "0.1.0"
+
 # Color codes for terminal output
 class Colors:
     RED = '\033[91m'
@@ -322,6 +325,9 @@ def main():
                         help='無視するディレクトリ/ファイル（カンマ区切り）')
     parser.add_argument('--output', '-o', type=str,
                         help='結果をファイルに保存（CSV形式）')
+    parser.add_argument('--version', action='version',
+                        version=f'%(prog)s {__version__}',
+                        help='ツールのバージョンを表示して終了')
     
     args = parser.parse_args()
     


### PR DESCRIPTION
## Summary
- expose tool version with `--version` option
- document new option in English and Japanese READMEs

## Testing
- `python -m py_compile check-license scripts/*.py`
- `./check-license --version`
- `./check-license --help | head -n 15`


------
https://chatgpt.com/codex/tasks/task_e_688cc0c577f0832ab7348d69c16609c7